### PR TITLE
Allow as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ ENDIF()
 # Define installation directory for all projects
 # ----------------------------------------------------------------------
 
-SET(install_dir ${spatialitecpp_dir}/".")
+SET(install_dir ".")
 
 # ======================================================================
 # Define library linking and flags for testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ PROJECT(SpatiaLiteCpp)
 # Set SpatiaLiteCpp directory
 # ----------------------------------------------------------------------
 
-SET(spatialitecpp_dir "${CMAKE_SOURCE_DIR}")
+SET(spatialitecpp_dir "${PROJECT_SOURCE_DIR}")
 SET(spatialitecpp_dir_inc "${spatialitecpp_dir}/include")
 
 # ======================================================================
@@ -43,6 +43,7 @@ IF (NOT sharedptr_dir_inc)
 ENDIF()
 
 # Set SpatiaLite directory and libraries
+# Allow env variable or top-level project to override
 SET(spatialite_dir_inc $ENV{spatialite_dir_inc})
 IF (NOT spatialite_dir_inc)
     IF(WIN32)
@@ -59,12 +60,14 @@ IF (NOT spatialite_dir_lib)
         SET(spatialite_dir_lib "/usr/lib/x86_64-linux-gnu")
     ENDIF()
 ENDIF()
-IF(WIN32)
-    SET(spatialite_lib "${spatialite_dir_lib}/spatialite_i.lib")
-    SET(sqlite3_lib "${spatialite_dir_lib}/sqlite3_i.lib")
-ELSE()
-    SET(spatialite_lib "${spatialite_dir_lib}/libspatialite.so")
-    SET(sqlite3_lib "${spatialite_dir_lib}/libsqlite3.so")
+IF (NOT spatialite_lib AND NOT sqlite3_lib)
+    IF(WIN32)
+        SET(spatialite_lib "${spatialite_dir_lib}/spatialite_i.lib")
+        SET(sqlite3_lib "${spatialite_dir_lib}/sqlite3_i.lib")
+    ELSE()
+        SET(spatialite_lib "${spatialite_dir_lib}/libspatialite.so")
+        SET(sqlite3_lib "${spatialite_dir_lib}/libsqlite3.so")
+    ENDIF()
 ENDIF()
 
 # Set SQLiteCpp directory and libraries
@@ -77,7 +80,7 @@ ENDIF()
 # Define installation directory for all projects
 # ----------------------------------------------------------------------
 
-SET(install_dir ".")
+SET(install_dir ${spatialitecpp_dir}/".")
 
 # ======================================================================
 # Define library linking and flags for testing
@@ -94,18 +97,18 @@ IF (${SPATIALITECPP_BUILD_TEST})
             SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
         ENDIF()
     ENDIF()
-    ADD_SUBDIRECTORY(test)
+    ADD_SUBDIRECTORY(${spatialitecpp_dir}/test)
 ENDIF()
 
 # ======================================================================
 # Define project sub-directories
 # ----------------------------------------------------------------------
 
-ADD_SUBDIRECTORY(ext/SQLiteCppLocal)
-ADD_SUBDIRECTORY(src)
+ADD_SUBDIRECTORY(${spatialitecpp_dir}/ext/SQLiteCppLocal)
+ADD_SUBDIRECTORY(${spatialitecpp_dir}/src)
 
 IF(${SPATIALITECPP_BUILD_EXAMPLES})
-    ADD_SUBDIRECTORY(examples)
+    ADD_SUBDIRECTORY(${spatialitecpp_dir}/examples)
 ENDIF()
 
 # ======================================================================

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ find $REPO_WORKDIR -iname ".*" -type f -delete || exit 1
 
 # Build documentation
 ./build.sh -a
-cp -r docs/* $REPO_WORKDIR/
+cp -r docs/. $REPO_WORKDIR/
 
 # Commit and push updates
 pushd $REPO_WORKDIR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,7 +117,11 @@ SET_TARGET_PROPERTIES(SpatiaLiteCpp PROPERTIES LINKER_LANGUAGE CXX)
 # Install library and header files
 # --------------------------------------------------
 
-SET(install_dir_lib "${install_dir}/lib")
+IF (NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    SET(install_dir_lib "${install_dir}/lib")
+ELSE()
+    SET(install_dir_lib "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+ENDIF()
 
 IF(${SPATIALITECPP_BUILD_DYNAMIC})
     INSTALL(TARGETS SpatiaLiteCpp


### PR DESCRIPTION
Allow SpatiaLiteCpp to build when it is not a top-level project (eg. a submodule/subproject)
