### PR TITLE
Xml option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ ENDIF(NOT DEFINED CMAKE_INSTALL_PREFIX)
 # Check for command line arguments
 # ----------------------------------------------------------------------
 
+OPTION(SPATIALITECPP_USE_LIBXML2 "Expect libxml2 from spatialite" ON)
 OPTION(SPATIALITECPP_BUILD_EXAMPLES "Build examples project" OFF)
 OPTION(SPATIALITECPP_BUILD_DYNAMIC "Build as dynamic library" OFF)
 OPTION(SPATIALITECPP_BUILD_TEST "Build as test project" OFF)

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ find $REPO_WORKDIR -iname ".*" -type f -delete || exit 1
 
 # Build documentation
 ./build.sh -a
-cp -r docs/* $REPO_WORKDIR/
+cp -r docs/. $REPO_WORKDIR/
 
 # Commit and push updates
 pushd $REPO_WORKDIR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,7 @@ SET(spatialitecpp_hdr
     "${spatialitecpp_dir}/include/SpatiaLiteCpp/SpatiaLiteCppAbi.h"
     "${spatialitecpp_dir}/include/SpatiaLiteCpp/VectorLayersList.h"
     "${spatialitecpp_dir}/include/SpatiaLiteCpp/WfsCatalog.h"
-    "${spatialitecpp_dir}/include/SpatiaLiteCpp/WfsSchema.h"
-    "${spatialitecpp_dir}/include/SpatiaLiteCpp/XmlBlob.h"
-    "${spatialitecpp_dir}/include/SpatiaLiteCpp/XmlDocument.h")
+    "${spatialitecpp_dir}/include/SpatiaLiteCpp/WfsSchema.h")
 
 # ==================================================
 # Set source files
@@ -54,9 +52,20 @@ SET(spatialitecpp_src
     "${spatialitecpp_dir}/src/Shapefile.cpp"
     "${spatialitecpp_dir}/src/VectorLayersList.cpp"
     "${spatialitecpp_dir}/src/WfsCatalog.cpp"
-    "${spatialitecpp_dir}/src/WfsSchema.cpp"
-    "${spatialitecpp_dir}/src/XmlBlob.cpp"
-    "${spatialitecpp_dir}/src/XmlDocument.cpp")
+    "${spatialitecpp_dir}/src/WfsSchema.cpp")
+
+# ==================================================
+# Set xml2 specific files
+# --------------------------------------------------
+
+IF(${SPATIALITECPP_USE_LIBXML2})
+    LIST(APPEND spatialitecpp_hdr
+        "${spatialitecpp_dir}/include/SpatiaLiteCpp/XmlBlob.h"
+        "${spatialitecpp_dir}/include/SpatiaLiteCpp/XmlDocument.h")
+    LIST(APPEND spatialitecpp_src
+        "${spatialitecpp_dir}/src/XmlBlob.cpp"
+        "${spatialitecpp_dir}/src/XmlDocument.cpp")
+ENDIF()
 
 # ==================================================
 # Set documentation files


### PR DESCRIPTION
Makes libxml2 optional, just like the main SpatiaLite project.
